### PR TITLE
Use Lazysodium for Android, GSON and Apache Commons Codec

### DIFF
--- a/crypto-v2-libsodium/src/main/java/net/aholbrook/paseto/crypto/v2/libsodium/LibSodiumV2CryptoProvider.java
+++ b/crypto-v2-libsodium/src/main/java/net/aholbrook/paseto/crypto/v2/libsodium/LibSodiumV2CryptoProvider.java
@@ -17,19 +17,19 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 package net.aholbrook.paseto.crypto.v2.libsodium;
 
-import com.goterl.lazycode.lazysodium.LazySodiumJava;
-import com.goterl.lazycode.lazysodium.SodiumJava;
 import net.aholbrook.paseto.crypto.KeyPair;
 import net.aholbrook.paseto.crypto.v2.V2CryptoProvider;
+import com.goterl.lazycode.lazysodium.LazySodiumAndroid;
+import com.goterl.lazycode.lazysodium.SodiumAndroid;
 
 public class LibSodiumV2CryptoProvider extends V2CryptoProvider {
-	private final LazySodiumJava sodium;
+	private final LazySodiumAndroid sodium;
 
 	public LibSodiumV2CryptoProvider() {
-		this(new LazySodiumJava(new SodiumJava()));
+		this(new LazySodiumAndroid(new SodiumAndroid()));
 	}
 
-	public LibSodiumV2CryptoProvider(LazySodiumJava sodium) {
+	public LibSodiumV2CryptoProvider(LazySodiumAndroid sodium) {
 		this.sodium = sodium;
 	}
 

--- a/encoding-json-jackson/src/main/java/net/aholbrook/paseto/encoding/json/jackson/JacksonJsonProvider.java
+++ b/encoding-json-jackson/src/main/java/net/aholbrook/paseto/encoding/json/jackson/JacksonJsonProvider.java
@@ -17,66 +17,31 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 package net.aholbrook.paseto.encoding.json.jackson;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import net.aholbrook.paseto.encoding.exception.EncodingException;
-import net.aholbrook.paseto.encoding.json.jackson.mixin.KeyIdMixIn;
-import net.aholbrook.paseto.encoding.json.jackson.mixin.TokenMixIn;
-import net.aholbrook.paseto.service.KeyId;
-import net.aholbrook.paseto.service.Token;
-import net.aholbrook.paseto.encoding.EncodingProvider;
-
-import java.io.IOException;
-import java.time.OffsetDateTime;
+import encoding.EncodingProvider;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class JacksonJsonProvider implements EncodingProvider {
-	private final ObjectMapper objectMapper;
 
 	public JacksonJsonProvider() {
-		this(new ObjectMapper());
-		objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-		registerMixins(objectMapper);
-		objectMapper.registerModule(offsetDateTimeModule());
-	}
-
-	public JacksonJsonProvider(ObjectMapper objectMapper) {
-		this.objectMapper = objectMapper;
 	}
 
 	@Override
 	public String encode(Object o) {
 		if (o == null) { return null; }
 
-		try {
-			return objectMapper.writeValueAsString(o);
-		} catch (JsonProcessingException e) {
-			throw new EncodingException("Error while encoding json.", e);
-		}
+		GsonBuilder builder = new GsonBuilder();
+		Gson gson = builder.create();
+		return gson.toJson(o);
 	}
 
 	@Override
 	public <_Out> _Out decode(String s, Class<_Out> clazz) {
 		if (s == null) { return null; }
 
-		try {
-			return objectMapper.readValue(s, clazz);
-		} catch (IOException e) {
-			throw new EncodingException("Error while decoding json.", e);
-		}
-	}
-
-	public static void registerMixins(ObjectMapper mapper) {
-		mapper.addMixIn(Token.class, TokenMixIn.class);
-		mapper.addMixIn(KeyId.class, KeyIdMixIn.class);
-	}
-
-	public static SimpleModule offsetDateTimeModule() {
-		SimpleModule module = new SimpleModule();
-		module.addSerializer(OffsetDateTime.class, new OffsetDateTimeSerializer());
-		module.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
-		return module;
+		GsonBuilder builder = new GsonBuilder();
+		Gson gson = builder.create();
+		return gson.fromJson(s, clazz);
 	}
 }

--- a/paseto-core/src/main/java/net/aholbrook/paseto/util/Hex.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/util/Hex.java
@@ -1,9 +1,14 @@
 package net.aholbrook.paseto.util;
 
-import javax.xml.bind.DatatypeConverter;
+import org.apache.commons.codec.DecoderException;
 
 public class Hex {
 	public static byte[] decode(String s) {
-		return DatatypeConverter.parseHexBinary(s);
+		try {
+			return org.apache.commons.codec.binary.Hex.decodeHex(s.toCharArray());
+		} catch (DecoderException e) {
+			e.printStackTrace();
+		}
+        return new byte[0];
 	}
 }


### PR DESCRIPTION
Here are some (non-working) quick changes to make this library compatible Android.

You also need to import the following dependencies in some way, which I haven't invested enough time to make it work with Gradle. In crypto-v2-libsodium/build.gradle:
```
implementation "com.goterl.lazycode:lazysodium-android:3.5.0@aar"
implementation "net.java.dev.jna:jna:4.5.2@aar"
```

In encoding-json-jackson/build.gradle:
```
implementation "com.google.code.gson:gson:2.8.5"
```

In paseto-core/build.gradle:
```
implementation "commons-codec:commons-codec:1.9"
```

The library probably needs to be configured as an Android library and use Android's Gradle plugin in order to correctly imports the .aar files.