### PR TITLE
Allow reading the Footer as a String.

### DIFF
--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/LocalTokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/LocalTokenService.java
@@ -51,6 +51,11 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 	}
 
 	@Override
+	public String getFooter(String token) {
+		return paseto.extractFooter(token);
+	}
+
+	@Override
 	public <_FooterType> _FooterType getFooter(String token, Class<_FooterType> footerClass) {
 		return paseto.extractFooter(token, footerClass);
 	}

--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/PublicTokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/PublicTokenService.java
@@ -51,6 +51,10 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 		return result;
 	}
 
+	public String getFooter(String token) {
+		return paseto.extractFooter(token);
+	}
+
 	public <_FooterType> _FooterType getFooter(String token, Class<_FooterType> footerClass) {
 		return paseto.extractFooter(token, footerClass);
 	}

--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/TokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/TokenService.java
@@ -34,6 +34,8 @@ public abstract class TokenService<_TokenType extends Token> {
 	abstract public <_FooterType> TokenWithFooter<_TokenType, _FooterType> decodeWithFooter(String token,
 			Class<_FooterType> footerClass);
 
+	abstract public String getFooter(String token);
+
 	abstract public <_FooterType> _FooterType getFooter(String token, Class<_FooterType> footerClass);
 
 	protected final void validateToken(_TokenType token) {

--- a/test/src/main/java/net/aholbrook/paseto/test/PasetoV2ServiceTest.java
+++ b/test/src/main/java/net/aholbrook/paseto/test/PasetoV2ServiceTest.java
@@ -247,6 +247,15 @@ public class PasetoV2ServiceTest extends PasetoServiceTest {
 	}
 
 	@Test
+	public void v2Service_local_extractFooter_asString() {
+		TestVector<Token, KeyId> tv = TokenTestVectors.TV_1_V2_LOCAL_WITH_FOOTER;
+		TokenService<Token> service = tokenLocalService(tv.getB());
+
+		String result = service.getFooter(tv.getToken());
+		Assert.assertEquals("{\"kid\":\"key-1\"}", result);
+	}
+
+	@Test
 	public void v2Service_public_extractFooter() {
 		TestVector<Token, KeyId> tv = TokenTestVectors.TV_1_V2_PUBLIC_WITH_FOOTER;
 		TokenService<Token> service = tokenPublicService();
@@ -255,6 +264,15 @@ public class PasetoV2ServiceTest extends PasetoServiceTest {
 		Assert.assertEquals(tv.getFooter(), result);
 	}
 
+	@Test
+	public void v2Service_public_extractFooter_asString() {
+		TestVector<Token, KeyId> tv = TokenTestVectors.TV_1_V2_PUBLIC_WITH_FOOTER;
+		TokenService<Token> service = tokenPublicService();
+
+		String result = service.getFooter(tv.getToken());
+		Assert.assertEquals("{\"kid\":\"key-1\"}", result);
+	}
+	
 	// Test defaultValidityPeriod
 	@Test
 	public void v2Service_local_defaultValidityPeriod() {


### PR DESCRIPTION
Allow reading the Footer to a String by skipping the decode step if the FooterClass parameter is not passed to #getFooter.

This is useful when the footer is a simple string identifier.