### PR TITLE
Add support for unlimited expiry tokens by leaving the expiry time null.

### DIFF
--- a/paseto-core/src/main/java/net/aholbrook/paseto/claims/Claims.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/claims/Claims.java
@@ -12,6 +12,10 @@ public class Claims {
 			new IssuedInPast(), new CurrentlyValid()
 	};
 
+	public static final Claim[] DEFAULT_NO_EXPIRY_CLAIM_CHECKS = new Claim[] {
+			new IssuedInPast(), new CurrentlyValid(true)
+	};
+
 	public static VerificationContext verify(Token token) {
 		return verify(token, DEFAULT_CLAIM_CHECKS);
 	}

--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/LocalTokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/LocalTokenService.java
@@ -3,6 +3,7 @@ package net.aholbrook.paseto.service;
 import net.aholbrook.paseto.Paseto;
 import net.aholbrook.paseto.PasetoV1;
 import net.aholbrook.paseto.PasetoV2;
+import net.aholbrook.paseto.PasetoV4;
 import net.aholbrook.paseto.TokenWithFooter;
 import net.aholbrook.paseto.claims.Claim;
 import net.aholbrook.paseto.claims.Claims;
@@ -14,8 +15,8 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 	private final KeyProvider keyProvider;
 
 	private LocalTokenService(Paseto paseto, KeyProvider keyProvider, Claim[] claims,
-			Duration defaultValidityPeriod, Class<_TokenType> tokenClass) {
-		super(paseto, claims, defaultValidityPeriod, tokenClass);
+			Duration defaultValidityPeriod, Class<_TokenType> tokenClass, boolean allowTokensWithoutExpiration) {
+		super(paseto, claims, defaultValidityPeriod, tokenClass, allowTokensWithoutExpiration);
 		this.keyProvider = keyProvider;
 	}
 
@@ -107,6 +108,7 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 		private Paseto paseto;
 		private Long defaultValidityPeriod = null;
 		private Claim[] claims = Claims.DEFAULT_CLAIM_CHECKS;
+		private boolean allowTokensWithoutExpiration = false;
 
 		public Builder(Class<_TokenType> tokenClass, KeyProvider keyProvider) {
 			this.tokenClass = tokenClass;
@@ -123,6 +125,11 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 			return this;
 		}
 
+		public Builder<_TokenType> withV4() {
+			this.paseto = new PasetoV4.Builder().build();
+			return this;
+		}
+
 		public Builder<_TokenType> withPaseto(Paseto paseto) {
 			this.paseto = paseto;
 			return this;
@@ -130,6 +137,16 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 
 		public Builder<_TokenType> withDefaultValidityPeriod(Long seconds) {
 			this.defaultValidityPeriod = seconds;
+			return this;
+		}
+
+		public Builder<_TokenType> withoutExpiration() {
+			this.allowTokensWithoutExpiration = true;
+
+			if (claims == Claims.DEFAULT_CLAIM_CHECKS) {
+				claims = Claims.DEFAULT_NO_EXPIRY_CLAIM_CHECKS;
+			}
+
 			return this;
 		}
 
@@ -145,7 +162,8 @@ public class LocalTokenService<_TokenType extends Token> extends TokenService<_T
 					keyProvider,
 					claims,
 					defaultValidityPeriod != null ? Duration.ofSeconds(defaultValidityPeriod) : null,
-					tokenClass);
+					tokenClass,
+					allowTokensWithoutExpiration);
 		}
 	}
 }

--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/PublicTokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/PublicTokenService.java
@@ -3,6 +3,7 @@ package net.aholbrook.paseto.service;
 import net.aholbrook.paseto.Paseto;
 import net.aholbrook.paseto.PasetoV1;
 import net.aholbrook.paseto.PasetoV2;
+import net.aholbrook.paseto.PasetoV4;
 import net.aholbrook.paseto.TokenWithFooter;
 import net.aholbrook.paseto.claims.Claim;
 import net.aholbrook.paseto.claims.Claims;
@@ -16,8 +17,8 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 	private final KeyProvider keyProvider;
 
 	private PublicTokenService(Paseto paseto, KeyProvider keyProvider, Claim[] claims,
-			Duration defaultValidityPeriod, Class<_TokenType> tokenClass) {
-		super(paseto, claims, defaultValidityPeriod, tokenClass);
+			Duration defaultValidityPeriod, Class<_TokenType> tokenClass, boolean allowTokensWithoutExpiration) {
+		super(paseto, claims, defaultValidityPeriod, tokenClass, allowTokensWithoutExpiration);
 		this.keyProvider = keyProvider;
 	}
 
@@ -110,6 +111,7 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 		private Paseto paseto;
 		private Long defaultValidityPeriod = null;
 		private Claim[] claims = Claims.DEFAULT_CLAIM_CHECKS;
+		private boolean allowTokensWithoutExpiration = false;
 
 		public Builder(Class<_TokenType> tokenClass, KeyProvider keyProvider) {
 			this.tokenClass = tokenClass;
@@ -126,6 +128,11 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 			return this;
 		}
 
+		public Builder<_TokenType> withV4() {
+			this.paseto = new PasetoV4.Builder().build();
+			return this;
+		}
+
 		public Builder<_TokenType> withPaseto(Paseto paseto) {
 			this.paseto = paseto;
 			return this;
@@ -133,6 +140,16 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 
 		public Builder<_TokenType> withDefaultValidityPeriod(Long defaultValidityPeriod) {
 			this.defaultValidityPeriod = defaultValidityPeriod;
+			return this;
+		}
+
+		public Builder<_TokenType> withoutExpiration() {
+			this.allowTokensWithoutExpiration = true;
+
+			if (claims == Claims.DEFAULT_CLAIM_CHECKS) {
+				claims = Claims.DEFAULT_NO_EXPIRY_CLAIM_CHECKS;
+			}
+
 			return this;
 		}
 
@@ -148,7 +165,8 @@ public class PublicTokenService<_TokenType extends Token> extends TokenService<_
 					keyProvider,
 					claims,
 					defaultValidityPeriod != null ? Duration.ofSeconds(defaultValidityPeriod) : null,
-					tokenClass);
+					tokenClass,
+					allowTokensWithoutExpiration);
 		}
 	}
 }

--- a/paseto-core/src/main/java/net/aholbrook/paseto/service/TokenService.java
+++ b/paseto-core/src/main/java/net/aholbrook/paseto/service/TokenService.java
@@ -16,13 +16,15 @@ public abstract class TokenService<_TokenType extends Token> {
 	final Class<_TokenType> tokenClass;
 	final Claim[] claims;
 	private final Duration defaultValidityPeriod;
+	private final boolean allowTokensWithoutExpiration;
 
 	TokenService(Paseto paseto, Claim[] claims, Duration defaultValidityPeriod,
-			Class<_TokenType> tokenClass) {
+			Class<_TokenType> tokenClass, boolean allowTokensWithoutExpiration) {
 		this.paseto = paseto;
 		this.tokenClass = tokenClass;
 		this.defaultValidityPeriod = defaultValidityPeriod;
 		this.claims = claims;
+		this.allowTokensWithoutExpiration = allowTokensWithoutExpiration;
 	}
 
 	abstract public String encode(_TokenType token);
@@ -62,7 +64,7 @@ public abstract class TokenService<_TokenType extends Token> {
 			if (defaultValidityPeriod != null) {
 				OffsetDateTime issuedAt = Instant.ofEpochSecond(token.getIssuedAt()).atOffset(ZoneOffset.UTC);
 				token.setExpiration(issuedAt.plus(defaultValidityPeriod).toEpochSecond());
-			} else {
+			} else if (!allowTokensWithoutExpiration) {
 				throw new MissingClaimException(Token.CLAIM_EXPIRATION, "TokenService", token);
 			}
 		}

--- a/paseto-core/src/test/java/net/aholbrook/paseto/ClaimVerificationTest.java
+++ b/paseto-core/src/test/java/net/aholbrook/paseto/ClaimVerificationTest.java
@@ -38,7 +38,7 @@ public class ClaimVerificationTest {
 	private VerificationContext standardVerification(Token token, OffsetDateTime time) {
 		Claim[] claims = new Claim[] {
 				new IssuedInPast(time, IssuedInPast.DEFAULT_ALLOWABLE_DRIFT),
-				new CurrentlyValid(time, CurrentlyValid.DEFAULT_ALLOWABLE_DRIFT)
+				new CurrentlyValid(time, CurrentlyValid.DEFAULT_ALLOWABLE_DRIFT, false)
 		};
 
 		return Claims.verify(token, claims);
@@ -109,6 +109,19 @@ public class ClaimVerificationTest {
 			AssertUtils.assertMissingClaimException(() -> Claims.verify(token, new Claim[]{new CurrentlyValid()}),
 					CurrentlyValid.NAME, token, Token.CLAIM_EXPIRATION);
 		});
+	}
+
+	@Test
+	@DisplayName("A token without an expiration time is valid if allowWithoutExpiration is set to true.")
+	public void tokenVerification_null_expired_allowed() {
+		Token token = new Token().setIssuedAt(0L);
+
+		Claim[] claims = new Claim[] {
+				new IssuedInPast(IssuedInPast.DEFAULT_ALLOWABLE_DRIFT),
+				new CurrentlyValid(CurrentlyValid.DEFAULT_ALLOWABLE_DRIFT, true)
+		};
+
+		Claims.verify(token, claims);
 	}
 
 	@Test

--- a/paseto-core/src/test/java/net/aholbrook/paseto/PasetoV1ServiceTest.java
+++ b/paseto-core/src/test/java/net/aholbrook/paseto/PasetoV1ServiceTest.java
@@ -317,6 +317,20 @@ public class PasetoV1ServiceTest extends PasetoServiceTest {
 		});
 	}
 
+	@ParameterizedTest(name = "{displayName} with {0}")
+	@MethodSource("net.aholbrook.paseto.Sources#pasetoV1Builders")
+	public void v1Service_public_noExpiryAllowed(Paseto.Builder builder) {
+		Token token = new Token().setTokenId("id").setIssuedAt(0L);
+		PublicTokenService<Token> service = new PublicTokenService.Builder<>(Token.class, rfcPublicKeyProvider())
+				.withPaseto(builder.build())
+				.withoutExpiration()
+				.build();
+
+		String s = service.encode(token);
+		Token token2 = service.decode(s);
+		Assertions.assertNotNull(token2.getIssuedAt());
+		Assertions.assertNull(token2.getExpiration());
+	}
 
 	// Constructors / Builder options
 	@ParameterizedTest(name = "{displayName} with {0}")

--- a/paseto-core/src/test/java/net/aholbrook/paseto/PasetoV2ServiceTest.java
+++ b/paseto-core/src/test/java/net/aholbrook/paseto/PasetoV2ServiceTest.java
@@ -310,6 +310,21 @@ public class PasetoV2ServiceTest extends PasetoServiceTest {
 
 	@ParameterizedTest(name = "{displayName} with {0}")
 	@MethodSource("net.aholbrook.paseto.Sources#pasetoV2Builders")
+	public void v2Service_local_noExpiryAllowed(Paseto.Builder builder) {
+		Token token = new Token().setTokenId("id").setIssuedAt(0L);
+		LocalTokenService<Token> service = new LocalTokenService.Builder<>(Token.class, rfcLocalKeyProvider())
+				.withPaseto(builder.build())
+				.withoutExpiration()
+				.build();
+
+		String s = service.encode(token);
+		Token token2 = service.decode(s);
+		Assertions.assertNotNull(token2.getIssuedAt());
+		Assertions.assertNull(token2.getExpiration());
+	}
+
+	@ParameterizedTest(name = "{displayName} with {0}")
+	@MethodSource("net.aholbrook.paseto.Sources#pasetoV2Builders")
 	public void v2Service_public_defaultValidityPeriod(Paseto.Builder builder) {
 		Token token = new Token().setTokenId("id");
 		PublicTokenService<Token> service = new PublicTokenService.Builder<>(Token.class, rfcPublicKeyProvider())
@@ -335,6 +350,21 @@ public class PasetoV2ServiceTest extends PasetoServiceTest {
 			AssertUtils.assertMissingClaimException(() ->
 					service.encode(token), "TokenService", token, Token.CLAIM_EXPIRATION);
 		});
+	}
+
+	@ParameterizedTest(name = "{displayName} with {0}")
+	@MethodSource("net.aholbrook.paseto.Sources#pasetoV2Builders")
+	public void v2Service_public_noExpiryAllowed(Paseto.Builder builder) {
+		Token token = new Token().setTokenId("id").setIssuedAt(0L);
+		PublicTokenService<Token> service = new PublicTokenService.Builder<>(Token.class, rfcPublicKeyProvider())
+				.withPaseto(builder.build())
+				.withoutExpiration()
+				.build();
+
+		String s = service.encode(token);
+		Token token2 = service.decode(s);
+		Assertions.assertNotNull(token2.getIssuedAt());
+		Assertions.assertNull(token2.getExpiration());
 	}
 
 


### PR DESCRIPTION
Adds support for unlimited expiry tokens by leaving the token expiry time null.

Must opt-in for this behavior:
```
PublicTokenService<Token> service = new PublicTokenService.Builder<>(Token.class, keyProvider())
		.withV4()
		.withoutExpiration()
		.build();
```