### PR TITLE
Update libs, enable auto publishing.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -255,6 +255,7 @@ ij_java_wrap_long_lines = false
 
 [*.{kt,kts}] # See danger section: https://pinterest.github.io/ktlint/1.1.0/rules/configuration-ktlint/
 ktlint_code_style = intellij_idea
+ktlint_standard_no-unused-imports = enabled
 ktlint_standard_multiline-expression-wrapping = disabled
 ktlint_standard_string-template-indent = disabled
 ij_continuation_indent_size = 4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,7 @@ allprojects {
 
         withType<Test>().configureEach {
             useJUnitPlatform()
+            jvmArgs = listOf("-Xshare:off")
 
             testLogging {
                 events("failed", "skipped")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,12 +8,11 @@ gradleUpdateVersions = "1.1.0"
 gradleVersions = "0.53.0"
 # @keep used manually for jacoco config, see build.gradle.kts
 jacoco = "0.8.14"
-junit-jupiter = "6.0.3"
-junit-platform = "6.0.3"
+junit = "6.0.3"
 # @keep jvm target
 jvm = "17"
-kotest = "6.1.4"
-kotlin = "2.3.10"
+kotest = "6.1.10"
+kotlin = "2.3.20"
 kotlinter = "5.4.2"
 kotlinx-serialization = "1.10.0"
 mockk = "1.14.9"
@@ -22,10 +21,10 @@ nmcp = "1.4.4"
 [libraries]
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
-junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Dec 04 12:38:49 EST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/paseto/build.gradle.kts
+++ b/paseto/build.gradle.kts
@@ -144,7 +144,7 @@ nmcpAggregation {
         username = System.getenv("PUBLISH_USER")
         password = System.getenv("PUBLISH_PASS")
 
-        publishingType = "USER_MANAGED"
+        publishingType = "AUTOMATIC"
     }
 }
 

--- a/paseto/src/test/kotlin/net/aholbrook/paseto/protocol/TestVectors.kt
+++ b/paseto/src/test/kotlin/net/aholbrook/paseto/protocol/TestVectors.kt
@@ -5,7 +5,6 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import net.aholbrook.paseto.InternalApi
 import net.aholbrook.paseto.crypto.withTestNonce
 import net.aholbrook.paseto.protocol.key.AsymmetricPublicKey
 import net.aholbrook.paseto.protocol.key.AsymmetricSecretKey

--- a/paseto/src/test/kotlin/net/aholbrook/paseto/protocol/key/SymmetricKeyTests.kt
+++ b/paseto/src/test/kotlin/net/aholbrook/paseto/protocol/key/SymmetricKeyTests.kt
@@ -11,7 +11,6 @@ import net.aholbrook.paseto.exception.KeyLengthException
 import net.aholbrook.paseto.exception.KeyPurposeException
 import net.aholbrook.paseto.exception.KeyVersionException
 import net.aholbrook.paseto.keyV4Local
-import net.aholbrook.paseto.keyV4Public
 import net.aholbrook.paseto.protocol.Purpose
 import net.aholbrook.paseto.protocol.Version
 import org.junit.jupiter.api.Test

--- a/paseto/src/test/kotlin/net/aholbrook/paseto/rules/NotExpiredTests.kt
+++ b/paseto/src/test/kotlin/net/aholbrook/paseto/rules/NotExpiredTests.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
-import kotlin.longArrayOf
 
 class NotExpiredTests {
     @ParameterizedTest

--- a/paseto/src/testFixtures/kotlin/net/aholbrook/paseto/ServiceTestVectorFixtures.kt
+++ b/paseto/src/testFixtures/kotlin/net/aholbrook/paseto/ServiceTestVectorFixtures.kt
@@ -14,7 +14,6 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import java.time.Instant
-import kotlin.collections.forEach
 
 @Serializable
 data class ServiceTestVectors(val name: String, val version: String, val tests: List<ServiceTestVector>)


### PR DESCRIPTION
Updates:

- gradle 9.3.1 → 9.4.1
- kotest 6.1.4 → 6.1.10
- kotlin 2.3.10 → 2.3.20


Additionally:
- Turn on auto publishing from Github Actions.
- Turn on ktlint import cleanup.
- Disable JVM share warning in tests.
- Remove unused imports.